### PR TITLE
Create Japanese Translation

### DIFF
--- a/_locales/ja/messages.json
+++ b/_locales/ja/messages.json
@@ -12,7 +12,7 @@
     "message": "このツイートのリツイートを見る"
   },
   "twitterQuotesQuotes": {
-    "message": "件の引用リツイート"
+    "message": "引用リツイート"
   },
   "twitterQuotesQuotesTitle": {
     "message": "このツイートの引用リツイートを見る"

--- a/_locales/ja/messages.json
+++ b/_locales/ja/messages.json
@@ -1,0 +1,26 @@
+{
+  "twitterQuotesExtensionName": {
+    "message": "Twitter Quotes are back!"
+  },
+  "twitterQuotesExtensionDescription": {
+    "message": "Twitter Quotes are back!"
+  },
+  "twitterQuotesRetweet": {
+    "message": "件のリツイート"
+  },
+  "twitterQuotesRetweetTitle": {
+    "message": "このツイートのリツイートを見る"
+  },
+  "twitterQuotesQuotes": {
+    "message": "件の引用リツイート"
+  },
+  "twitterQuotesQuotesTitle": {
+    "message": "このツイートの引用リツイートを見る"
+  },
+  "twitterQuotesLikes": {
+    "message": "件のいいね"
+  },
+  "twitterQuotesLikesTitle": {
+    "message": "このツイートのいいねを見る"
+  }
+}


### PR DESCRIPTION
In the Japanese version of Twitter, "Retweets" was displayed as "(number)件のリツイート".
![00](https://github.com/josecebe/twitter-quotes-are-back/assets/22564007/07abf171-816e-4371-9548-85c771511ab9)

"件" means items or cases, even of course retweets.
However, this plugin does not show the number of "Quotes".
For this reason, only `twitterQuotesQuotes` is a simple translation.